### PR TITLE
Sic Standardization

### DIFF
--- a/transcripts/first_draft.md
+++ b/transcripts/first_draft.md
@@ -514,7 +514,7 @@ of this brilliant work of art. The practical mixing, meeting, agreeing with the
 spiritual, it is all here.
 
 But spirituality is not an easy thing to confront. You might find yourself able
-to wrap your mind around a simple math problem or a basic newspaper article, or,
+to wrap your mind around a simple math problem or a basic newspaper article, or [*sic*],
 but intellect is much less subjective.
 
 What is sprituality, and how have I found spiritual peace and serenity in


### PR DESCRIPTION
Add a sic for improper grammar

On line 533 we write "Because and [*sic*] he could no longer specify...", signifying the use of [sic] when a grammatical error is made; either we remove that sic or add one here.