### PR TITLE
Consistency of stutters versus pauses

### DIFF
--- a/transcripts/first_draft.md
+++ b/transcripts/first_draft.md
@@ -805,7 +805,7 @@ just have to find that rare strip.
 
 Speaking philosophically about the entire Garfield franchise, it's an incredibly
 accurate depiction of life. Its bold lines and bright colors are merely a
-facade, a, a red herring, a lie. This cartoon is not a cartoon at all. It is not
+facade, a- a red herring, a lie. This cartoon is not a cartoon at all. It is not
 caricature. It is not caricature despite adopting caricature as its visual
 style and tone.
 
@@ -842,7 +842,7 @@ legs, but these inputs of touch, sight, hearing, *et cetera*, these senses are
 the triggers of the mind, as we see here, the mind is something greater. It is
 the originator of ideas, and ideas are forever, immortal.
 
-Immortality through thought, a, a major theme in literature and philosophy. And
+Immortality through thought, a- a major theme in literature and philosophy. And
 isn't that what Mr. Jim Davis, himself, has achieved? Will he live forever?
 
 The universe will continue to spread and spread outward, and entropy will turn


### PR DESCRIPTION
Changed the pattern TEXT a, a TEXT to TEXT a- a TEXT

On line 615, we use a hyphen to denote a stutter for the word "I" `As overexcited as I was, I- I managed to take in her response. ` It makes sense that we should use hyphens for stuttering rather than commas (which we normally use for pauses), since we wouldn't have to write [*sic*] to explain why he repeated a word. Similarly, if he's only stuttering the first letter of a longer word, like on line 611 `I pointed at the paper and said, "L-Like this! Like this!` I think the reason you used commas for these instances of TEXT a, a TEXT is because they're single words, but it should not be an exception.
